### PR TITLE
Enable jsx-a11y/recommended in react rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2022-01-04
+- Enable `jsx-a11y/recommended` rules for react configuration [@shawnmcknight](https://github.com/shawnmcknight)
+
 ## [0.0.1] - 2022-01-04
 ### Added
-- Initial release by [@shawnmcknight](https://github.com/shawnmcknight)
+- Initial release [@shawnmcknight](https://github.com/shawnmcknight)
 
 [Unreleased]: https://github.com/storis/eslint-config/compare/0.0.1...HEAD
+[0.0.2]: https://github.com/storis/eslint-config/compare/0.0.2...0.0.1
 [0.0.1]: https://github.com/storis/eslint-config/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.9.0",
@@ -45,7 +45,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
-        "jest": "^27.4.0",
+        "jest": "^26.0.0 || ^27.0.0",
         "prettier": "^2.5.0",
         "typescript": "^4.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "STORIS eslint configurations",
   "main": "index.js",
   "scripts": {

--- a/react.js
+++ b/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ['airbnb', 'airbnb-typescript', './lib/shared'],
+	extends: ['airbnb', 'airbnb-typescript', 'jsx-a11y/recommended', './lib/shared'],
 
 	env: { browser: true },
 
@@ -47,10 +47,10 @@ module.exports = {
 		'react/jsx-indent-props': ['error', 'tab'],
 
 		// permit spreading of props
-		'react/jsx-props-no-spreading': ['off'],
+		'react/jsx-props-no-spreading': 'off',
 
 		// typescript is better at prop-types than `prop-types`
-		'react/prop-types': ['off'],
+		'react/prop-types': 'off',
 
 		// check effect dependencies
 		'react-hooks/exhaustive-deps': 'warn',

--- a/react.js
+++ b/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ['airbnb', 'airbnb-typescript', 'jsx-a11y/recommended', './lib/shared'],
+	extends: ['airbnb', 'airbnb-typescript', 'plugin:jsx-a11y/recommended', './lib/shared'],
 
 	env: { browser: true },
 


### PR DESCRIPTION
This change enables `jsx-a11y/recommended` in the react rules and prepares for a release 0.0.2.