### PR TITLE
Fix changelog so compare works properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release [@shawnmcknight](https://github.com/shawnmcknight)
 
-[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.1...HEAD
-[0.0.2]: https://github.com/storis/eslint-config/compare/0.0.2...0.0.1
+[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.2...HEAD
+[0.0.2]: https://github.com/storis/eslint-config/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/storis/eslint-config/releases/tag/0.0.1


### PR DESCRIPTION
The order of comparison was incorrect in the changelog.  This corrects the changelog so the links compare properly.