### PR TITLE
Disable react/react-in-jsx-scope rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.0.2] - 2022-01-04
-- Enable `jsx-a11y/recommended` rules for react configuration [@shawnmcknight](https://github.com/shawnmcknight)
+- Enable `jsx-a11y/recommended` rules for react configuration ([#5](https://github.com/STORIS/eslint-config/pull/7))
 
 ## [0.0.1] - 2022-01-04
 ### Added
-- Initial release [@shawnmcknight](https://github.com/shawnmcknight)
+- Initial release
 
 [Unreleased]: https://github.com/storis/eslint-config/compare/0.0.2...HEAD
 [0.0.2]: https://github.com/storis/eslint-config/compare/0.0.1...0.0.2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storis/eslint-config",
   "version": "0.0.2",
-  "description": "STORIS eslint configurations",
+  "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext js,ts --cache && echo \"eslint: no lint errors\"",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:STORIS/eslint-config.git"
+    "url": "git+https://github.com/STORIS/eslint-config.git"
   },
   "keywords": [
     "eslint",
@@ -21,6 +21,10 @@
   ],
   "author": "STORIS",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/STORIS/eslint-config/issues"
+  },
+  "homepage": "https://github.com/STORIS/eslint-config#readme",
   "engines": {
     "node": "^16.0.0"
   },

--- a/react.js
+++ b/react.js
@@ -52,6 +52,10 @@ module.exports = {
 		// typescript is better at prop-types than `prop-types`
 		'react/prop-types': 'off',
 
+		// disable react-in-jsx-scope (must use @babel/preset-react option { runtime: 'automatic' })
+		// see: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html and https://babeljs.io/docs/en/babel-preset-react/#runtime
+		'react/react-in-jsx-scope': 'off',
+
 		// check effect dependencies
 		'react-hooks/exhaustive-deps': 'warn',
 


### PR DESCRIPTION
This PR disables the `react/react-in-jsx-scope` rule since when using the new JSX transform for React 17+, importing React is no longer a requirement, provided that the transform is being used.