### PR TITLE
Prepare for 0.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2022-01-5
+- Disable `react/react-in-jsx-scope` under the assumption that the React 17 JSX transform will be enabled in babel configuration ([#11](https://github.com/STORIS/eslint-config/pull/11))
+
 ## [0.0.2] - 2022-01-04
 - Enable `jsx-a11y/recommended` rules for react configuration ([#5](https://github.com/STORIS/eslint-config/pull/7))
 
@@ -13,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.2...HEAD
+[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.3...HEAD
+[0.0.3]: https://github.com/storis/eslint-config/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/storis/eslint-config/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/storis/eslint-config/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares for 0.0.3 release by bumping the version and updating the CHANGELOG.