### PR TITLE
Enable consistent-type-exports rule

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -85,7 +85,11 @@ module.exports = {
 			},
 		],
 
-		// prefer type imports
+		// prefer type imports and exports
+		'@typescript-eslint/consistent-type-exports': [
+			'error',
+			{ fixMixedExportsWithInlineTypeSpecifier: true },
+		],
 		'@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
 
 		// enforce consistent order of class members


### PR DESCRIPTION
This PR enables the `@typescript-eslint/consistent-type-exports` rule in all configurations.  It uses the `fixMixedExportsWithInlineTypeSpecifier` to allow for mixed type and regular exports to be autofixed inline.