### PR TITLE
Prepare for release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.3] - 2022-01-5
+## [0.0.4] - 2022-01-05
+- Enable `@typescript-eslint/consistent-type-exports` rule to ensure that type-only exports are always prefixed with the `type` keyword ([#13](https://github.com/STORIS/eslint-config/pull/13))
+
+## [0.0.3] - 2022-01-05
 - Disable `react/react-in-jsx-scope` under the assumption that the React 17 JSX transform will be enabled in babel configuration ([#11](https://github.com/STORIS/eslint-config/pull/11))
 
 ## [0.0.2] - 2022-01-04
@@ -16,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.3...HEAD
+[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.4...HEAD
+[0.0.4]: https://github.com/storis/eslint-config/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/storis/eslint-config/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/storis/eslint-config/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/storis/eslint-config/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares for 0.0.4 release by bumping the version and updating the CHANGELOG.