### PR TITLE
Better handling of no-unused-vars

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -39,10 +39,6 @@ module.exports = {
 		'@typescript-eslint/restrict-template-expressions': 'off',
 		'@typescript-eslint/unbound-method': 'off',
 
-		// disable no-unused-vars (enabled by airbnb-typescript) as TS provides better checking
-		// see https://typescript-eslint.io/docs/linting/troubleshooting#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-		'@typescript-eslint/no-unused-vars': 'off',
-
 		// enforce curly brace usage
 		curly: ['error', 'all'],
 

--- a/react.js
+++ b/react.js
@@ -1,5 +1,11 @@
 module.exports = {
-	extends: ['airbnb', 'airbnb-typescript', 'plugin:jsx-a11y/recommended', './lib/shared'],
+	extends: [
+		'airbnb',
+		'airbnb-typescript',
+		'plugin:react/jsx-runtime',
+		'plugin:jsx-a11y/recommended',
+		'./lib/shared',
+	],
 
 	env: { browser: true },
 
@@ -48,6 +54,9 @@ module.exports = {
 
 		// permit spreading of props
 		'react/jsx-props-no-spreading': 'off',
+
+		// React triggers no-unused-vars rules
+		'react/jsx-uses-react': 'off',
 
 		// typescript is better at prop-types than `prop-types`
 		'react/prop-types': 'off',


### PR DESCRIPTION
This PR removes the override disabling `@typescript-eslint/no-unused-vars` as there was a mixup between the behavior of that and the `no-undef` rule.  Additionally, it extends `plugin:react/jsx-runtime` in the react configuration to ensure that when React is imported when it does not need to be an error is trigger for `no-unused-vars`.