### PR TITLE
Relocate no-restricted-syntax from node to shared

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -50,6 +50,27 @@ module.exports = {
 		'arrow-body-style': ['error', 'as-needed', { requireReturnForObjectLiteral: false }],
 		'prefer-arrow-callback': ['error', { allowNamedFunctions: false, allowUnboundThis: true }],
 
+		// Allow use of ForOfStatement - no-restricted-syntax does not allow us to turn off a rule. This block overrides the airbnb rule entirely
+		// https://github.com/airbnb/javascript/blob/7152396219e290426a03e47837e53af6bcd36bbe/packages/eslint-config-airbnb-base/rules/style.js#L257-L263
+		'no-restricted-syntax': [
+			'error',
+			{
+				selector: 'ForInStatement',
+				message:
+					'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+			},
+			{
+				selector: 'LabeledStatement',
+				message:
+					'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+			},
+			{
+				selector: 'WithStatement',
+				message:
+					'`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+			},
+		],
+
 		// underscore dangle will be handled by @typescript-eslint/naming-convention
 		'no-underscore-dangle': 'off',
 

--- a/node.js
+++ b/node.js
@@ -27,27 +27,6 @@ module.exports = {
 			// allow trailing ASC and DESC on enumerations
 			{ selector: 'enumMember', filter: { regex: '^.*?_(ASC|DESC)$', match: true }, format: null },
 		],
-
-		// Allow use of ForOfStatement - no-restricted-syntax does no allow us to turn off a rule. This block overrides the airbnb rule entirely
-		// https://github.com/airbnb/javascript/blob/7152396219e290426a03e47837e53af6bcd36bbe/packages/eslint-config-airbnb-base/rules/style.js#L257-L263
-		'no-restricted-syntax': [
-			'error',
-			{
-				selector: 'ForInStatement',
-				message:
-					'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
-			},
-			{
-				selector: 'LabeledStatement',
-				message:
-					'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
-			},
-			{
-				selector: 'WithStatement',
-				message:
-					'`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
-			},
-		],
 	},
 
 	overrides: [


### PR DESCRIPTION
Currently the `no-restricted-syntax` override to allow "for of" expressions was enabled for node but not react.  This change moves the rule from `node` to `shared` so it will be enabled for both node and react.