### PR TITLE
Prepare for release 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6] - 2022-01-05
+### Changed
+- Relocate override of `no-restricted-syntax` rule to shared configuration so that it is enabled for both `node` and `react` configurations ([#17](https://github.com/STORIS/eslint-config/pull/17))
+
 ## [0.0.5] - 2022-01-05
 ### Changed
 - Remove override on `@typescript-eslint/no-unused-vars` to enable it and extend `plugin:react/jsx-runtime` in react configuration ([#15](https://github.com/STORIS/eslint-config/pull/15))
@@ -26,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.5...HEAD
+[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.6...HEAD
+[0.0.6]: https://github.com/storis/eslint-config/compare/0.0.5...0.0.6
 [0.0.5]: https://github.com/storis/eslint-config/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/storis/eslint-config/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/storis/eslint-config/compare/0.0.2...0.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares for 0.0.6 release by bumping the version and updating the CHANGELOG.