### PR TITLE
Eliminate pathgroup

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -81,7 +81,6 @@ module.exports = {
 		'import/order': [
 			'error',
 			{
-				pathGroups: [{ pattern: '#*/**', group: 'internal', position: 'before' }],
 				'newlines-between': 'never',
 				groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
 				alphabetize: { order: 'asc', caseInsensitive: true },


### PR DESCRIPTION
The `pathGroups` setting in the eslint config is unnecessary.  `eslint-plugin-import` will treat import paths that are not relative, node built-ins, or from `node_modules` as  `internal`.  The sequence of the existing `groups` ensures that the internal group is already in the right place, and the alphabetizing of imports ensures the proper sequence within the group.  Essentially this configuration is doing nothing currently and can be dropped.