### PR TITLE
Prepare for 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7] - 2022-01-14
+### Changed
+- Eliminate use of `pathGroups` setting for `eslint-plugin-import` as the behavior without the setting is the same as with it ([#20](https://github.com/STORIS/eslint-config/pull/20))
+
 ## [0.0.6] - 2022-01-05
 ### Changed
 - Relocate override of `no-restricted-syntax` rule to shared configuration so that it is enabled for both `node` and `react` configurations ([#17](https://github.com/STORIS/eslint-config/pull/17))
@@ -30,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.6...HEAD
+[Unreleased]: https://github.com/storis/eslint-config/compare/0.0.7...HEAD
+[0.0.7]: https://github.com/storis/eslint-config/compare/0.0.6...0.0.7
 [0.0.6]: https://github.com/storis/eslint-config/compare/0.0.5...0.0.6
 [0.0.5]: https://github.com/storis/eslint-config/compare/0.0.4...0.0.5
 [0.0.4]: https://github.com/storis/eslint-config/compare/0.0.3...0.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares for 0.0.7 release by bumping the version and updating the CHANGELOG.