### PR TITLE
Add an override to exclude prefer-default-export from constants.ts

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -191,5 +191,13 @@ module.exports = {
 				'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
 			},
 		},
+
+		{
+			files: ['**/constants.ts'],
+			rules: {
+				// allow named exports in constants files
+				'import/prefer-default-export': 'off',
+			},
+		},
 	],
 };

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -197,6 +197,7 @@ module.exports = {
 			rules: {
 				// allow named exports in constants files
 				'import/prefer-default-export': 'off',
+				'import/no-default-export': 'error',
 			},
 		},
 	],

--- a/node.js
+++ b/node.js
@@ -31,12 +31,7 @@ module.exports = {
 
 	overrides: [
 		{
-			files: [
-				'**/*.types.ts',
-				'**/types/*.ts',
-				'**/*.schema.ts',
-				'**/instances/**',
-			],
+			files: ['**/*.types.ts', '**/types/*.ts', '**/*.schema.ts', '**/instances/**'],
 			rules: {
 				'import/prefer-default-export': 'off',
 				'import/no-default-export': 'error',

--- a/node.js
+++ b/node.js
@@ -34,7 +34,6 @@ module.exports = {
 			files: [
 				'**/*.types.ts',
 				'**/types/*.ts',
-				'**/constants.ts',
 				'**/*.schema.ts',
 				'**/instances/**',
 			],


### PR DESCRIPTION
This PR adds an override that excludes `prefer-default-export` from `constants.ts` files.