### PR TITLE
Consolidate named exports overrides in shared

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -125,9 +125,9 @@ module.exports = {
 		},
 
 		{
-			files: ['**/index.ts', '**/index.tsx', '**/*.gql.ts'],
+			files: ['**/index.ts', '**/index.tsx', '**/*.gql.ts', '**/constants.ts'],
 			rules: {
-				// in index and gql files, always use named exports
+				// prefer named exports for certain file types
 				'import/prefer-default-export': 'off',
 				'import/no-default-export': 'error',
 			},
@@ -189,15 +189,6 @@ module.exports = {
 
 				// allow empty arrow functions
 				'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
-			},
-		},
-
-		{
-			files: ['**/constants.ts'],
-			rules: {
-				// allow named exports in constants files
-				'import/prefer-default-export': 'off',
-				'import/no-default-export': 'error',
 			},
 		},
 	],


### PR DESCRIPTION
In the shared configuration there are two override blocks to prefer named exports and nothing more.  To avoid duplication, this PR consolidates those overrides into a single block.