### PR TITLE
Add explicit-module-boundary-types rule to nodejs set

### DIFF
--- a/nodejs.js
+++ b/nodejs.js
@@ -4,6 +4,9 @@ module.exports = {
 	settings: { 'import/resolver': { 'babel-module': { extensions: ['.ts'] } } },
 
 	rules: {
+		// enforce return types on module boundaries
+		'@typescript-eslint/explicit-module-boundary-types': 'error',
+
 		// set up naming convention rules
 		'@typescript-eslint/naming-convention': [
 			'error',


### PR DESCRIPTION
This PR updates the `nodejs` rule set to activate the [explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types) rule to ensure that the external facing API of modules has return types.