### PR TITLE
Only use explicit-module-boundary-types on ts files

### DIFF
--- a/nodejs.js
+++ b/nodejs.js
@@ -4,9 +4,6 @@ module.exports = {
 	settings: { 'import/resolver': { 'babel-module': { extensions: ['.ts'] } } },
 
 	rules: {
-		// enforce return types on module boundaries
-		'@typescript-eslint/explicit-module-boundary-types': 'error',
-
 		// set up naming convention rules
 		'@typescript-eslint/naming-convention': [
 			'error',
@@ -33,6 +30,14 @@ module.exports = {
 	},
 
 	overrides: [
+		{
+			files: ['**/*.ts'],
+			rules: {
+				// enforce return types on module boundaries
+				'@typescript-eslint/explicit-module-boundary-types': 'error',
+			},
+		},
+
 		{
 			files: ['**/*.types.ts', '**/types/*.ts', '**/*.schema.ts', '**/instances/**'],
 			rules: {


### PR DESCRIPTION
When working in a mixed js/ts codebase, the `explicit-module-boundary-types` error was being triggered on `js` files.  This changes the `nodejs` configuration so that error will only be triggered on `ts` files.