### PR TITLE
Better support for js files

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -12,16 +12,6 @@ module.exports = {
 	plugins: ['jest'],
 
 	rules: {
-		// disable rules turned on by @typescript-eslint/recommended-requiring-type-checking which are too noisy
-		// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.ts
-		'@typescript-eslint/no-unsafe-argument': 'off',
-		'@typescript-eslint/no-unsafe-assignment': 'off',
-		'@typescript-eslint/no-unsafe-call': 'off',
-		'@typescript-eslint/no-unsafe-member-access': 'off',
-		'@typescript-eslint/no-unsafe-return': 'off',
-		'@typescript-eslint/restrict-template-expressions': 'off',
-		'@typescript-eslint/unbound-method': 'off',
-
 		// enforce curly brace usage
 		curly: ['error', 'all'],
 
@@ -98,6 +88,16 @@ module.exports = {
 			files: ['**/*.ts'],
 			extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
 			rules: {
+				// disable rules turned on by @typescript-eslint/recommended-requiring-type-checking which are too noisy
+				// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.ts
+				'@typescript-eslint/no-unsafe-argument': 'off',
+				'@typescript-eslint/no-unsafe-assignment': 'off',
+				'@typescript-eslint/no-unsafe-call': 'off',
+				'@typescript-eslint/no-unsafe-member-access': 'off',
+				'@typescript-eslint/no-unsafe-return': 'off',
+				'@typescript-eslint/restrict-template-expressions': 'off',
+				'@typescript-eslint/unbound-method': 'off',
+
 				// force explicit member accessibility modifiers
 				'@typescript-eslint/explicit-member-accessibility': 'error',
 			},

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -85,7 +85,7 @@ module.exports = {
 
 	overrides: [
 		{
-			files: ['**/*.ts'],
+			files: ['**/*.ts', '**/*.tsx'],
 			extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
 			rules: {
 				// disable rules turned on by @typescript-eslint/recommended-requiring-type-checking which are too noisy

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -170,5 +170,15 @@ module.exports = {
 				'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
 			},
 		},
+
+		{
+			files: ['**/*.js'],
+			rules: {
+				// disable rules that require type-checking which does not work well with js files
+				'@typescript-eslint/await-thenable': 'off',
+				'@typescript-eslint/restrict-plus-operands': 'off',
+				'@typescript-eslint/require-await': 'off',
+			},
+		},
 	],
 };

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -3,7 +3,6 @@ module.exports = {
 		'plugin:jest/recommended',
 		'plugin:jest/style',
 		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 		'plugin:import/typescript',
 		'prettier',
 	],
@@ -97,6 +96,7 @@ module.exports = {
 	overrides: [
 		{
 			files: ['**/*.ts'],
+			extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
 			rules: {
 				// force explicit member accessibility modifiers
 				'@typescript-eslint/explicit-member-accessibility': 'error',
@@ -168,16 +168,6 @@ module.exports = {
 
 				// allow empty arrow functions
 				'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
-			},
-		},
-
-		{
-			files: ['**/*.js'],
-			rules: {
-				// disable rules that require type-checking which does not work well with js files
-				'@typescript-eslint/await-thenable': 'off',
-				'@typescript-eslint/restrict-plus-operands': 'off',
-				'@typescript-eslint/require-await': 'off',
 			},
 		},
 	],


### PR DESCRIPTION
The @typescript-eslint rules which require type checking do not work very well in pure `js` files.  This PR changes it so those rules are only activated in `ts` and `tsx` files.