### PR TITLE
Add `eslint-plugin-testing-library` to React configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The package relies on the following peer dependencies which differ depending on 
 - `eslint-plugin-jsx-a11y`
 - `eslint-plugin-react`
 - `eslint-plugin-react-hooks`
+- `eslint-plugin-testing-library`
 
 ### Configuration
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -113,7 +113,7 @@ module.exports = {
 		},
 
 		{
-			files: ['**/test/**', '**/*.test.ts', '**/*.test.tsx'],
+			files: ['**/test/**', '**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
 			rules: {
 				// allow tests to create multiple classes
 				'max-classes-per-file': 'off',
@@ -129,12 +129,6 @@ module.exports = {
 					'error',
 					{ devDependencies: true, optionalDependencies: false, peerDependencies: false },
 				],
-
-				// allow explicit any in tests
-				'@typescript-eslint/no-explicit-any': 'off',
-
-				// allow non-null-assertions
-				'@typescript-eslint/no-non-null-assertion': 'off',
 
 				// disallow use of "it" for test blocks
 				'jest/consistent-test-it': ['error', { fn: 'test', withinDescribe: 'test' }],
@@ -165,6 +159,17 @@ module.exports = {
 
 				// prefer called with
 				'jest/prefer-called-with': 'error',
+			},
+		},
+
+		{
+			files: ['**/test/**', '**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
+			rules: {
+				// allow explicit any in tests
+				'@typescript-eslint/no-explicit-any': 'off',
+
+				// allow non-null-assertions
+				'@typescript-eslint/no-non-null-assertion': 'off',
 
 				// allow empty arrow functions
 				'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -113,7 +113,11 @@ module.exports = {
 		},
 
 		{
-			files: ['**/test/**', '**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+			files: [
+				'**/test/**/*.[jt]s?(x)',
+				'**/__tests__/**/*.[jt]s?(x)',
+				'**/?(*.)+(spec|test).[jt]s?(x)',
+			],
 			rules: {
 				// allow tests to create multiple classes
 				'max-classes-per-file': 'off',
@@ -163,7 +167,7 @@ module.exports = {
 		},
 
 		{
-			files: ['**/test/**', '**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
+			files: ['**/test/**/*.ts?(x)', '**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
 			rules: {
 				// allow explicit any in tests
 				'@typescript-eslint/no-explicit-any': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7141,9 +7141,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -14641,9 +14641,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-jsx-a11y": "^6.5.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-testing-library": "^5.2.0",
         "jest": "^26.0.0 || ^27.0.0",
         "typescript": "^4.5.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-react": "7.29.4",
         "eslint-plugin-react-hooks": "4.4.0",
+        "eslint-plugin-testing-library": "5.2.1",
         "husky": "7.0.4",
         "jest": "27.5.1",
         "lint-staged": "12.3.7",
@@ -3601,6 +3602,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.2.1.tgz",
+      "integrity": "sha512-88qJv6uzYALtiYJDzhelP3ov0Px/GLgnu+UekjjDxL2nMyvgdTyboKqcDBsvFPmAeizlCoSWOjeBN4DxO0BxaA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.13.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -12104,6 +12121,15 @@
       "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-testing-library": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.2.1.tgz",
+      "integrity": "sha512-88qJv6uzYALtiYJDzhelP3ov0Px/GLgnu+UekjjDxL2nMyvgdTyboKqcDBsvFPmAeizlCoSWOjeBN4DxO0BxaA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.13.0"
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-testing-library": "^5.2.0",
     "jest": "^26.0.0 || ^27.0.0",
     "typescript": "^4.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.4.0",
+    "eslint-plugin-testing-library": "5.2.1",
     "husky": "7.0.4",
     "jest": "27.5.1",
     "lint-staged": "12.3.7",

--- a/react.js
+++ b/react.js
@@ -9,7 +9,7 @@ module.exports = {
 
 	env: { browser: true },
 
-	plugins: ['react-hooks'],
+	plugins: ['react-hooks', 'testing-library'],
 
 	settings: {
 		'import/resolver': {
@@ -88,6 +88,12 @@ module.exports = {
 				'@typescript-eslint/naming-convention': ['error', { selector: 'default', format: null }],
 				camelcase: 'off',
 			},
+		},
+
+		{
+			// apply testing library rules only to test files
+			files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+			extends: ['plugin:testing-library/react'],
 		},
 	],
 };


### PR DESCRIPTION
This PR adds `eslint-plugin-testing-library` to the react configuration and requires it as a peer dependency.  The plugin has been added to an override that targets tests only, [as described in the project's readme](https://github.com/testing-library/eslint-plugin-testing-library#run-the-plugin-only-against-test-files).

Applied the regex recommended by the testing-library eslint rule's docs (which is based on [Jest's defaults](https://jestjs.io/docs/configuration#testmatch-arraystring)) to the shared config.  To do this, I've split its override in two: a general override covering JavaScript and TypeScript test suites and another that is specific to TypeScript.