### PR TITLE
Optional peer dependency: eslint-plugin-testing-library 

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
     },
     "eslint-plugin-react-hooks": {
       "optional": true
+    },
+    "eslint-plugin-testing-library": {
+      "optional": true
     }
   },
   "prettier": "@storis/prettier-config"


### PR DESCRIPTION
eslint-plugin-testing-library should have been included in `peerDependenciesMeta` as an optional peer dependency when it was introduced in #92 