### PR TITLE
Update eslint-config-airbnb-typescript and all peer dependency ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "8.12.0",
         "eslint-config-airbnb": "19.0.4",
         "eslint-config-airbnb-base": "15.0.0",
-        "eslint-config-airbnb-typescript": "16.2.0",
+        "eslint-config-airbnb-typescript": "17.0.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-import-resolver-babel-module": "5.3.1",
         "eslint-import-resolver-webpack": "0.13.2",
@@ -37,23 +37,23 @@
         "node": "^16.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.9.0",
-        "@typescript-eslint/parser": "^5.9.0",
-        "eslint": "^8.6.0",
+        "@typescript-eslint/eslint-plugin": "^5.18.0",
+        "@typescript-eslint/parser": "^5.18.0",
+        "eslint": "^8.12.0",
         "eslint-config-airbnb": "^19.0.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-airbnb-typescript": "^16.1.0",
-        "eslint-config-prettier": "^8.3.0",
+        "eslint-config-airbnb-typescript": "^17.0.0",
+        "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-babel-module": "^5.3.0",
         "eslint-import-resolver-webpack": "^0.13.0",
         "eslint-plugin-import": "^2.25.0",
-        "eslint-plugin-jest": "^25.3.0 || ^26.0.0",
+        "eslint-plugin-jest": "^26.0.0",
         "eslint-plugin-jsx-a11y": "^6.5.0",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-react": "^7.29.0",
+        "eslint-plugin-react-hooks": "^4.4.0",
         "eslint-plugin-testing-library": "^5.2.0",
-        "jest": "^26.0.0 || ^27.0.0",
-        "typescript": "^4.5.0"
+        "jest": "^27.0.0",
+        "typescript": "^4.6.0"
       },
       "peerDependenciesMeta": {
         "eslint-config-airbnb": {
@@ -3311,15 +3311,15 @@
       }
     },
     "node_modules/eslint-config-airbnb-typescript": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-16.2.0.tgz",
-      "integrity": "sha512-OUaMPZpTOZGKd5tXOjJ9PRU4iYNW/Z5DoHIynjsVK/FpkWdiY5+nxQW6TiJAlLwVI1l53xUOrnlZWtVBVQzuWA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
       "dev": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.3"
@@ -11897,9 +11897,9 @@
       }
     },
     "eslint-config-airbnb-typescript": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-16.2.0.tgz",
-      "integrity": "sha512-OUaMPZpTOZGKd5tXOjJ9PRU4iYNW/Z5DoHIynjsVK/FpkWdiY5+nxQW6TiJAlLwVI1l53xUOrnlZWtVBVQzuWA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "8.12.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-airbnb-base": "15.0.0",
-    "eslint-config-airbnb-typescript": "16.2.0",
+    "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-import-resolver-babel-module": "5.3.1",
     "eslint-import-resolver-webpack": "0.13.2",
@@ -58,23 +58,23 @@
     "typescript": "4.6.3"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.9.0",
-    "@typescript-eslint/parser": "^5.9.0",
-    "eslint": "^8.6.0",
+    "@typescript-eslint/eslint-plugin": "^5.18.0",
+    "@typescript-eslint/parser": "^5.18.0",
+    "eslint": "^8.12.0",
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-airbnb-typescript": "^16.1.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-babel-module": "^5.3.0",
     "eslint-import-resolver-webpack": "^0.13.0",
     "eslint-plugin-import": "^2.25.0",
-    "eslint-plugin-jest": "^25.3.0 || ^26.0.0",
+    "eslint-plugin-jest": "^26.0.0",
     "eslint-plugin-jsx-a11y": "^6.5.0",
-    "eslint-plugin-react": "^7.28.0",
-    "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-react": "^7.29.0",
+    "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-plugin-testing-library": "^5.2.0",
-    "jest": "^26.0.0 || ^27.0.0",
-    "typescript": "^4.5.0"
+    "jest": "^27.0.0",
+    "typescript": "^4.6.0"
   },
   "peerDependenciesMeta": {
     "eslint-config-airbnb": {


### PR DESCRIPTION
This PR updates to the latest version of `eslint-config-airbnb-typescript` which contains a breaking change for supported peer dependency ranges on `@typescript-eslint`.  To accommodate for that, the peer dependency range for `@typescript-eslint` needed to be bumped as well.  Since multiple peer dependency ranges are being bumped, I've also bumped every other peer dependency range to the latest semver minor.