### PR TITLE
Eliminate jest as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The package relies on the following peer dependencies which differ depending on 
 - `eslint-config-prettier`
 - `eslint-plugin-import`
 - `eslint-plugin-jest`
-- `jest`
 - `typescript`
 
 #### Required for NodeJs Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "eslint-plugin-react": "^7.29.0",
         "eslint-plugin-react-hooks": "^4.4.0",
         "eslint-plugin-testing-library": "^5.2.0",
-        "jest": "^27.0.0",
         "typescript": "^4.6.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "eslint-plugin-react": "^7.29.0",
     "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-plugin-testing-library": "^5.2.0",
-    "jest": "^27.0.0",
     "typescript": "^4.6.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
`jest` is unnecessary as a peer dependency.  Eliminating it will reduce the likelihood of merge conflicts due to changing jest revisions in the future.  Although to use `eslint-plugin-jest` you'd likely require `jest`, its not a definite requirement.