### PR TITLE
Prepare for release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2022-05-02
+
+- Eliminate `jest` as a peer dependency ([#116](https://github.com/STORIS/eslint-config/pull/116))
+
 ## [3.0.0] - 2022-04-05
 
 ### Breaking
@@ -113,7 +117,8 @@ This is flagged the first major release since the package has been working succe
 
 - Initial release
 
-[unreleased]: https://github.com/storis/eslint-config/compare/3.0.0...HEAD
+[unreleased]: https://github.com/storis/eslint-config/compare/3.1.0...HEAD
+[3.1.0]: https://github.com/storis/eslint-config/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/storis/eslint-config/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/storis/eslint-config/compare/1.0.1...2.0.0
 [1.0.1]: https://github.com/storis/eslint-config/compare/1.0.0...1.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/eslint-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/eslint-config",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@storis/prettier-config": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/eslint-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "STORIS eslint Configurations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the version to 3.1.0 and updates the CHANGELOG to reflect the changes.