### PR TITLE
Update support for Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,10 @@ workflows:
     # Inside the workflow, you define the jobs you want to run.
     jobs:
       - node/test:
-          # This is the node version to use for the `cimg/node` tag
-          # Relevant tags can be found on the CircleCI Developer Hub
-          # https://circleci.com/developer/images/image/cimg/node
-          version: '16.10'
+          matrix:
+            parameters:
+              version:
+                - 16.15
+                - 18.0
           # If you are using yarn, change the line below from "npm" to "yarn"
           pkg-manager: npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - 16.15
-                - 18.0
+                - '16.15'
+                - '18.0'
           # If you are using yarn, change the line below from "npm" to "yarn"
           pkg-manager: npm

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/STORIS/eslint-config#readme",
   "engines": {
-    "node": "^16.0.0"
+    "node": "^16.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@storis/prettier-config": "0.0.2",


### PR DESCRIPTION
This PR augments the `engines` property of `package.json` to support `^18.0.0` as well as `^16.0.0`.  The CI configuration was adjusted to run tests against both `16.15.0` and `18.0.0`.  Note: The circle [tags](https://circleci.com/developer/images/image/cimg/node) don't appear to have been updated to support `18.1.0` yet.