### PR TITLE
Set error level for no-unused-vars

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -81,6 +81,11 @@ module.exports = {
 
 		// disallow parameter properties in favor of explicit class declarations
 		'@typescript-eslint/no-parameter-properties': 'error',
+
+		// ensure unused variables are treated as an error
+		// overrides @typescript-eslint/recommended -- '@typescript-eslint/no-unused-vars': 'warn'
+		// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts
+		'@typescript-eslint/no-unused-vars': 'error',
 	},
 
 	overrides: [


### PR DESCRIPTION
Currently `@typescript-eslint/no-unused-vars` is set to `warn` level by `@typescript-eslint/recommended`.  It is preferable for this to be at `error` level.  This PR overrides the rule to set it to `error`.